### PR TITLE
Add stack resource type

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following arguments are supported:
 - [Environment](#environment)
 - [Registration Token](#registration-token)
 - [Registry](#registry)
+- [Stack](#stack)
 
 ### Environment
 
@@ -131,3 +132,58 @@ The following attributes are exported:
 * `description` - (Optional) The registry description.
 * `environment_id` - (Required) The ID of the environment to create the registry for.
 * `server_address` - (Required) The server address for the registry.
+
+### Stack
+
+Provides a Rancher Stack resource. This can be used to create and manage stacks on rancher.
+
+#### Example Usage
+
+```hcl
+# Create a new empty Rancher stack
+resource "rancher_stack" "external-dns" {
+  name = "route53"
+  description = "Route53 stack"
+  environment_id = "${rancher_environment.default.id}"
+  catalog_id = "library:route53:7"
+  scope = "system"
+  environment {
+    AWS_ACCESS_KEY = "MYKEY"
+    AWS_SECRET_KEY = "MYSECRET"
+    AWS_REGION = "eu-central-1"
+    TTL = "60"
+    ROOT_DOMAIN = "example.com"
+    ROUTE53_ZONE_ID = ""
+    HEALTH_CHECK_INTERVAL = "15"
+  }
+}
+```
+
+#### Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the stack.
+* `description` - (Optional) A stack description.
+* `environment_id` - (Required) The ID of the environment to create the stack for.
+* `docker_compose` - (Optional) The `docker-compose.yml` content to apply for the stack.
+* `rancher_compose` - (Optional) The `rancher-compose.yml` content to apply for the stack.
+* `environment` - (Optional) The environment to apply to interpret the docker-compose and rancher-compose files.
+* `catalog_id` - (Optional) The catalog ID to link this stack to. When provided, `docker_compose` and `rancher_compose` will be retrieved from the catalog unless they are overridden.
+* `scope` - (Optional) The scope to attach the stack to. Must be one of **user** or **system**. Defaults to **user**.
+* `start_on_create` - (Optional) Whether to start the stack automatically.
+
+#### Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the stack.
+* `name` - The name of the stack.
+* `description` - The description of the stack.
+* `environment_id` - (Required) The ID of the environment to create the stack for.
+* `docker_compose` - (Optional) The `docker-compose.yml` content to apply for the stack.
+* `rancher_compose` - (Optional) The `rancher-compose.yml` content to apply for the stack.
+* `environment` - (Optional) The environment to apply to interpret the docker-compose and rancher-compose files.
+* `catalog_id` - (Optional) The catalog ID to link this stack to. When provided, `docker_compose` and `rancher_compose` will be retrieved from the catalog unless they are overridden.
+* `scope` - (Optional) The scope to attach the stack to. Must be one of **user** or **system**. Defaults to **user**.
+* `start_on_create` - (Optional) Whether to start the stack automatically.

--- a/rancher/config.go
+++ b/rancher/config.go
@@ -3,6 +3,7 @@ package rancher
 import (
 	"log"
 
+	"github.com/rancher/go-rancher/catalog"
 	rancher "github.com/rancher/go-rancher/client"
 )
 
@@ -40,8 +41,9 @@ func (c *Config) EnvironmentClient(env string) (*rancher.RancherClient, error) {
 		return nil, nil
 	}
 
+	url := c.APIURL + "/projects/" + env + "/schemas"
 	client, err := rancher.NewRancherClient(&rancher.ClientOpts{
-		Url:       c.APIURL + "/projects/" + env + "/schemas",
+		Url:       url,
 		AccessKey: c.AccessKey,
 		SecretKey: c.SecretKey,
 	})
@@ -49,7 +51,27 @@ func (c *Config) EnvironmentClient(env string) (*rancher.RancherClient, error) {
 		return nil, err
 	}
 
-	log.Printf("[INFO] Rancher Client configured for url: %s", c.APIURL)
+	log.Printf("[INFO] Rancher Client configured for url: %s", url)
+
+	return client, nil
+}
+
+func (c *Config) CatalogClient() (*catalog.RancherClient, error) {
+	if c.APIURL == "" || c.AccessKey == "" || c.SecretKey == "" {
+		return nil, nil
+	}
+
+	url := c.APIURL + "-catalog/schemas"
+	client, err := catalog.NewRancherClient(&catalog.ClientOpts{
+		Url:       url,
+		AccessKey: c.AccessKey,
+		SecretKey: c.SecretKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[INFO] Rancher Catalog Client configured for url: %s", url)
 
 	return client, nil
 }

--- a/rancher/provider.go
+++ b/rancher/provider.go
@@ -34,6 +34,7 @@ func Provider() terraform.ResourceProvider {
 			"rancher_environment":        resourceRancherEnvironment(),
 			"rancher_registration_token": resourceRancherRegistrationToken(),
 			"rancher_registry":           resourceRancherRegistry(),
+			"rancher_stack":              resourceRancherStack(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/rancher/resource_rancher_stack.go
+++ b/rancher/resource_rancher_stack.go
@@ -1,0 +1,273 @@
+package rancher
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	rancher "github.com/rancher/go-rancher/client"
+)
+
+func resourceRancherStack() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRancherStackCreate,
+		Read:   resourceRancherStackRead,
+		Update: resourceRancherStackUpdate,
+		Delete: resourceRancherStackDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"environment_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"docker_compose": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"rancher_compose": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"environment": {
+				Type:     schema.TypeMap,
+				Optional: true,
+			},
+			"catalog_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Default:  "user",
+				Optional: true,
+			},
+			"start_on_create": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceRancherStackCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Creating Stack: %s", d.Id())
+	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	if err != nil {
+		return err
+	}
+
+	data, err := makeStackData(d, meta)
+	if err != nil {
+		return err
+	}
+
+	var newStack rancher.Environment
+	if err := client.Create("environment", data, &newStack); err != nil {
+		return err
+	}
+
+	d.SetId(newStack.Id)
+	log.Printf("[INFO] Stack ID: %s", d.Id())
+
+	return resourceRancherStackRead(d, meta)
+}
+
+func resourceRancherStackRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Refreshing Stack: %s", d.Id())
+	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	if err != nil {
+		return err
+	}
+
+	stack, err := client.Environment.ById(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Stack Name: %s", stack.Name)
+
+	d.Set("description", stack.Description)
+	d.Set("name", stack.Name)
+	d.Set("docker_compose", stack.DockerCompose)
+	d.Set("rancher_compose", stack.RancherCompose)
+	d.Set("environment", stack.Environment)
+
+	if stack.ExternalId == "" {
+		d.Set("scope", "user")
+		d.Set("catalog_id", "")
+	} else {
+		trimmedID := strings.TrimPrefix(stack.ExternalId, "system-")
+		if trimmedID == stack.ExternalId {
+			d.Set("scope", "user")
+		} else {
+			d.Set("scope", "system")
+		}
+		d.Set("catalog_id", strings.TrimPrefix(trimmedID, "catalog://"))
+	}
+
+	d.Set("start_on_create", stack.StartOnCreate)
+
+	return nil
+}
+
+func resourceRancherStackUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating Stack: %s", d.Id())
+	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	if err != nil {
+		return err
+	}
+
+	data, err := makeStackData(d, meta)
+	if err != nil {
+		return err
+	}
+
+	// TODO: upgrade stack if docker_compose, rancher_compose or environment have changed
+
+	var newStack rancher.Environment
+	stack, err := client.Environment.ById(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if err := client.Update("environment", &stack.Resource, data, &newStack); err != nil {
+		return err
+	}
+
+	return resourceRancherStackRead(d, meta)
+}
+
+func resourceRancherStackDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Deleting Stack: %s", d.Id())
+	id := d.Id()
+	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	if err != nil {
+		return err
+	}
+
+	stack, err := client.Environment.ById(id)
+	if err != nil {
+		return err
+	}
+
+	if err := client.Environment.Delete(stack); err != nil {
+		return fmt.Errorf("Error deleting Stack: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for stack (%s) to be removed", id)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"active", "removed", "removing"},
+		Target:     []string{"removed"},
+		Refresh:    StackStateRefreshFunc(client, id),
+		Timeout:    10 * time.Minute,
+		Delay:      1 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, waitErr := stateConf.WaitForState()
+	if waitErr != nil {
+		return fmt.Errorf(
+			"Error waiting for stack (%s) to be removed: %s", id, waitErr)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// StackStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// a Rancher Stack.
+func StackStateRefreshFunc(client *rancher.RancherClient, stackID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		stack, err := client.Environment.ById(stackID)
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return stack, stack.State, nil
+	}
+}
+
+func environmentFromMap(m map[string]interface{}) map[string]string {
+	result := make(map[string]string)
+	for k, v := range m {
+		result[k] = v.(string)
+	}
+	return result
+}
+
+func makeStackData(d *schema.ResourceData, meta interface{}) (data map[string]interface{}, err error) {
+	name := d.Get("name").(string)
+	description := d.Get("description").(string)
+
+	var externalID string
+	var dockerCompose string
+	var rancherCompose string
+	var environment map[string]string
+	if c, ok := d.GetOk("catalog_id"); ok {
+		if scope, ok := d.GetOk("scope"); ok && scope.(string) == "system" {
+			externalID = "system-"
+		}
+		catalogID := c.(string)
+		externalID += "catalog://" + catalogID
+
+		catalogClient, err := meta.(*Config).CatalogClient()
+		if err != nil {
+			return data, err
+		}
+		template, err := catalogClient.Template.ById(catalogID)
+		if err != nil {
+			return data, fmt.Errorf("Failed to get catalog template: %s", err)
+		}
+
+		dockerCompose = template.Files["docker-compose.yml"].(string)
+		// Pretend user provided this
+		d.Set("docker_compose", dockerCompose)
+		rancherCompose = template.Files["rancher-compose.yml"].(string)
+		// Pretend user provided this
+		d.Set("rancher_compose", rancherCompose)
+	}
+
+	if c, ok := d.GetOk("docker_compose"); ok {
+		dockerCompose = c.(string)
+	}
+	if c, ok := d.GetOk("rancher_compose"); ok {
+		rancherCompose = c.(string)
+	}
+	environment = environmentFromMap(d.Get("environment").(map[string]interface{}))
+
+	startOnCreate := d.Get("start_on_create")
+
+	data = map[string]interface{}{
+		"name":           &name,
+		"description":    &description,
+		"dockerCompose":  &dockerCompose,
+		"rancherCompose": &rancherCompose,
+		"environment":    &environment,
+		"externalId":     &externalID,
+		"startOnCreate":  &startOnCreate,
+	}
+
+	return data, nil
+}

--- a/rancher/resource_rancher_stack_test.go
+++ b/rancher/resource_rancher_stack_test.go
@@ -1,0 +1,266 @@
+package rancher
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	rancher "github.com/rancher/go-rancher/client"
+)
+
+func TestAccRancherStack(t *testing.T) {
+	var stack rancher.Environment
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRancherStackDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRancherStackConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancherStackExists("rancher_stack.foo", &stack),
+					testAccCheckRancherStackAttributes(&stack, "foo", "Terraform acc test group", "", "", "", emptyEnvironment, false),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancherStackUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancherStackExists("rancher_stack.foo", &stack),
+					testAccCheckRancherStackAttributes(&stack, "foo2", "Terraform acc test group - updated", "", "", "", emptyEnvironment, false),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancherStackComposeConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancherStackExists("rancher_stack.compose", &stack),
+					testAccCheckRancherStackAttributes(&stack, "compose", "Terraform acc test group - compose", "", "web: { image: nginx }", "web: { scale: 1 }", emptyEnvironment, true),
+				),
+			},
+			resource.TestStep{
+				Config: testAccRancherStackSystemCatalogConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRancherStackExists("rancher_stack.catalog", &stack),
+					testAccCheckRancherStackAttributes(&stack, "catalog", "Terraform acc test group - catalog", "system-catalog://library:route53:7", route53DockerCompose, route53RancherCompose, route53Environment, false),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckRancherStackExists(n string, stack *rancher.Environment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No App Name is set")
+		}
+
+		client := testAccProvider.Meta().(*Config)
+
+		foundStack, err := client.Environment.ById(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundStack.Resource.Id != rs.Primary.ID {
+			return fmt.Errorf("Stack not found")
+		}
+
+		*stack = *foundStack
+
+		return nil
+	}
+}
+
+func testAccCheckRancherStackAttributes(stack *rancher.Environment, stackName string, stackDesc string, externalID string, dockerCompose string, rancherCompose string, environment map[string]string, startOnCreate bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if stack.Name != stackName {
+			return fmt.Errorf("Bad name: %s should be: %s", stack.Name, stackName)
+		}
+
+		if stack.Description != stackDesc {
+			return fmt.Errorf("Bad description: %s should be: %s", stack.Description, stackDesc)
+		}
+
+		if stack.ExternalId != externalID {
+			return fmt.Errorf("Bad externalID: %s should be: %s", stack.ExternalId, externalID)
+		}
+
+		if stack.DockerCompose != dockerCompose {
+			return fmt.Errorf("Bad dockerCompose: %s should be: %s", stack.DockerCompose, dockerCompose)
+		}
+
+		if stack.RancherCompose != rancherCompose {
+			return fmt.Errorf("Bad rancherCompose: %s should be: %s", stack.RancherCompose, rancherCompose)
+		}
+
+		if len(stack.Environment) != len(environment) {
+			return fmt.Errorf("Bad environment size: %v should be: %v", len(stack.Environment), environment)
+		}
+
+		for k, v := range stack.Environment {
+			if environment[k] != v {
+				return fmt.Errorf("Bad environment value for %s: %s should be: %s", k, environment[k], v)
+			}
+		}
+
+		if stack.StartOnCreate != startOnCreate {
+			return fmt.Errorf("Bad startOnCreate: %s should be: %s", stack.StartOnCreate, startOnCreate)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckRancherStackDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Config)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "rancher_stack" {
+			continue
+		}
+		stack, err := client.Environment.ById(rs.Primary.ID)
+
+		if err == nil {
+			if stack != nil &&
+				stack.Resource.Id == rs.Primary.ID &&
+				stack.State != "removed" {
+				return fmt.Errorf("Stack still exists")
+			}
+		}
+
+		return nil
+	}
+	return nil
+}
+
+const testAccRancherStackConfig = `
+resource "rancher_stack" "foo" {
+	name = "foo"
+	description = "Terraform acc test group"
+	environment_id = "1a5"
+}
+`
+
+const testAccRancherStackUpdateConfig = `
+resource "rancher_stack" "foo" {
+	name = "foo2"
+	description = "Terraform acc test group - updated"
+	environment_id = "1a5"
+}
+`
+
+const testAccRancherStackComposeConfig = `
+resource "rancher_stack" "compose" {
+	name = "compose"
+	description = "Terraform acc test group - compose"
+	environment_id = "1a5"
+	docker_compose = "web: { image: nginx }"
+	rancher_compose = "web: { scale: 1 }"
+	start_on_create = true
+}
+`
+
+const testAccRancherStackSystemCatalogConfig = `
+resource "rancher_stack" "catalog" {
+	name = "catalog"
+	description = "Terraform acc test group - catalog"
+	environment_id = "1a5"
+	catalog_id = "library:route53:7"
+	scope = "system"
+	environment {
+		AWS_ACCESS_KEY = "MYKEY"
+		AWS_SECRET_KEY = "MYSECRET"
+		AWS_REGION = "eu-central-1"
+		ROOT_DOMAIN = "example.com"
+	}
+}
+`
+
+const route53DockerCompose = `route53:
+  image: rancher/external-dns:v0.5.0
+  expose: 
+   - 1000
+  environment:
+    AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+    AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+    AWS_REGION: ${AWS_REGION}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    ROUTE53_ZONE_ID: ${ROUTE53_ZONE_ID}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"
+`
+
+const route53RancherCompose = `.catalog:
+  name: "Route53 DNS"
+  version: "v0.5.0-rancher1"
+  description: "Rancher External DNS service powered by Amazon Route53. Requires Rancher version 0.44.0"
+  minimum_rancher_version: v1.1.0
+  questions:
+    - variable: "AWS_ACCESS_KEY"
+      label: "AWS Access Key ID"
+      description: "Access key ID for your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_SECRET_KEY"
+      label: "AWS Secret Access Key"
+      description: "Secret access key for your AWS account"
+      type: "string"
+      required: true
+    - variable: "AWS_REGION"
+      label: "AWS Region"
+      description: "AWS region name"
+      type: "string"
+      default: "us-west-2"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds"
+      type: "int"
+      default: 60
+      required: false
+    - variable: "ROOT_DOMAIN"
+      label: "Hosted Zone Name"
+      description: "Route53 hosted zone name (zone has to be pre-created). DNS entries will be created for <service>.<stack>.<environment>.<hosted zone>"
+      type: "string"
+      required: true
+    - variable: "ROUTE53_ZONE_ID"
+      label: "Hosted Zone ID"
+      description: "If there are multiple zones with the same name, then you must additionally specify the ID of the hosted zone to use."
+      type: "string"
+      required: false
+    - variable: "HEALTH_CHECK_INTERVAL"
+      label: "Health Check Interval"
+      description: "The health check interval for this service, in seconds. Raise this value if the total requests from your AWS account exceed the Route53 API rate limits."
+      type: "int"
+      min: 1
+      max: 999
+      default: 15
+      required: false
+
+route53:
+  health_check:
+    port: 1000
+    interval: ${HEALTH_CHECK_INTERVAL}000
+    unhealthy_threshold: 2
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 5000
+`
+
+var emptyEnvironment = map[string]string{}
+
+var route53Environment = map[string]string{
+	"AWS_ACCESS_KEY": "MYKEY",
+	"AWS_SECRET_KEY": "MYSECRET",
+	"AWS_REGION":     "eu-central-1",
+	"ROOT_DOMAIN":    "example.com",
+}


### PR DESCRIPTION
WIP: this allows to create/update/destroy stacks with basic information (`name`, `description`, `environment_id`), but I aim to support much more, as implemented in my [current type](https://github.com/camptocamp/terraform-provider-rancher/blob/master/rancher/resource_rancher_stack.go):
- `docker_compose`
- `rancher_compose`
- `environment`
- `external_id`
- `start_on_create`

Taken together, these 5 parameters allow to fully create a stack from a catalog template entry, which is extremely useful:
- if `external_id` is specified, then use the catalog API to retrieve the `docker_compose`, `rancher_compose` and default `environment` values
- let user override `docker_compose`, `rancher_compose` and `environment` keys

In addition to supporting them on create, I actually want to support updating them, which means:
- if `external_id` is modified, download new versions of `docker_compose` and `rancher_compose` from the catalog API
- if `docker_compose`, `rancher_compose` or `environment` is modified, upgrade the stack with these new parameters. Question: do we want to add a parameter for automatically finalizing the upgrade (e.g. `finalize_upgrade = true`)?

@blackjid do you have any comments on that API before I start implementing it?
